### PR TITLE
fix fetch_grades by allowing it to access websites that use TLS 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,36 @@ A Github Action that sends you a Telegram message when you get a new grade on [n
   - the action should run every 30 minutes in the future
 
     _disclaimer_: the action takes about 1 minute to run, which can eat a significant chunk of your 2000 minutes monthly quota, you can update the CRON expression in `.github/workflows/alert.yml` to make it run less frequently
+
+## Local development
+
+- [install poetry](https://python-poetry.org/docs/#installation)
+
+- install Python dependencies
+
+  ```bash
+  poetry install
+  ```
+
+- install the gecko driver for Selenium
+
+  on Mac:
+
+  ```bash
+  brew cask install geckodriver
+  ```
+
+- update `env.sh`
+
+- `export` the relevant environment variables
+
+  ```bash
+  source env.sh
+    export ECP_SSO_PASSWORD="your password"
+  ```
+
+- run the python script, it should print your grades in the console
+
+  ```bash
+  poetry run python fetch_grades.py
+  ```

--- a/fetch_grades.py
+++ b/fetch_grades.py
@@ -7,7 +7,6 @@ import os
 from tenacity import retry, before_sleep_log, stop_after_attempt
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -23,9 +22,12 @@ logger.setLevel(logging.DEBUG)
 
 
 def get_browser(headless=False):
-    options = Options()
+    options = webdriver.FirefoxOptions()
     options.headless = headless
-    return webdriver.Firefox(options=options)
+    # XXX: cas.ecp.fr uses TLS 1.0
+    profile = webdriver.FirefoxProfile()
+    profile.set_preference("security.tls.version.enable-deprecated", True)
+    return webdriver.Firefox(options=options, firefox_profile=profile)
 
 
 @retry(


### PR DESCRIPTION
Unfortunately, cas.ecp.fr uses TLS 1.0, disabled by default in the latest Firefox version.